### PR TITLE
Ensure queue is populated before reading from it

### DIFF
--- a/lib/TAP/Formatter/JUnit/Session.pm
+++ b/lib/TAP/Formatter/JUnit/Session.pm
@@ -160,7 +160,7 @@ sub close_test {
     }
 
     # track time for teardown, if needed
-    if ($timer_enabled) {
+    if ($timer_enabled && @{$queue}) {
         my $duration = $self->parser->end_time - $queue->[-1]->time;
         my $case     = $xml->testcase( {
             'name' => _squeaky_clean('(teardown)'),

--- a/t/timer.t
+++ b/t/timer.t
@@ -2,7 +2,7 @@
 
 use strict;
 use warnings;
-use Test::More tests => 4;
+use Test::More tests => 6;
 use TAP::Harness;
 use IO::Scalar;
 use File::Slurp qw(write_file);
@@ -28,6 +28,19 @@ timer_enabled: {
         use Test::More tests => 2;
         pass 'one';
         pass 'two';
+    |;
+    my $results = run_test($test, {
+        timer => 1,
+    } );
+    ok $results, 'got JUnit';
+    like $results, qr/time/ism, '... with timing information';
+}
+
+###############################################################################
+# When a test fails to run, JUnit output should be returned.
+timer_enabled_test_empty: {
+    my $test     = qq|
+        die;
     |;
     my $results = run_test($test, {
         timer => 1,


### PR DESCRIPTION
When a test dies before any TAP output is generated, like when it fails to
compile, the _queue will be empty.  In this case, if --timer is given, we
try to access an undefined value, causing TAP::Formatter::JUnit::Session
to die, which kills the TAP::Harness along with it.  Add a check to avoid
this issue, so the harness can continue testing.